### PR TITLE
Link to source code instead of user, update year

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -107,7 +107,7 @@
 
     <footer class="p-3 text-light">
         <div class="text-center">
-            <i class="fas fa-copyright" aria-label="&copy;"></i> Aleksandr Varaksa 1991&ndash;2021. Website by <a href="https://github.com/u32i64" target="_blank" rel="noopener" class="link-light">u32i64</a>.
+            <i class="fas fa-copyright" aria-label="&copy;"></i> Aleksandr Varaksa 1991&ndash;2024 &bull; <a href="https://github.com/iworld4us/iworld4us.github.io" target="_blank" rel="noopener" class="link-light">Website source code</a>
 
             <div class="d-block d-lg-none w-100"></div>
 


### PR DESCRIPTION
- Linked to website source code instead of specific user.
- Updated copyright year to current.